### PR TITLE
Provide userscript metadata that works

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,18 @@ Usage Example
 -------------
 
 Tell your user script to use MonkeyConfig by placing a `@require` directive in
-the metadata section:
+the metadata section alongside the `@grant` permissions it requires:
 
 ```javascript
 // ==UserScript==
 // @name           AwesomeScript
-// @require        https://raw.github.com/odyniec/MonkeyConfig/master/monkeyconfig.js
+// @description    My awesome userscript
+// @require        https://cdn.rawgit.com/odyniec/MonkeyConfig/51456c3a36b9b6febe61d1351de16466c90695d2/monkeyconfig.js
+// @grant          GM_getValue
+// @grant          GM_setValue
+// @grant          GM_addStyle
+// @grant          GM_registerMenuCommand
+// ==/UserScript==
 ```
 
 Then, call `MonkeyConfig()` to construct your configuration object:


### PR DESCRIPTION
The default userscript metadata doesn't work, and doesn't raise an error. Add a copy 'n' pasteable stanza that works so the library can be used without diving into the source code.

* `GM_addStyle` is needed for the default mode (iframe).
* `GM_registerMenuCommand` is needed for the suggested `menuCommand: true`
  option.
* GitHub [should no longer be used as a CDN](https://github.com/blog/1482-heads-up-nosniff-header-support-coming-to-chrome-and-firefox).
* GreasyFork requires 3rd party libraries served from GitHub-mirror CDNs to have either a [commit hash or a tag](https://greasyfork.org/en/help/external-scripts). In the absence of any MonkeyConfig tags/releases, use the former.